### PR TITLE
Bugfix/categories list

### DIFF
--- a/src/components/Nav/Nav.jsx
+++ b/src/components/Nav/Nav.jsx
@@ -1,9 +1,9 @@
+import { useDispatch } from 'react-redux';
+import { updateCategory } from 'redux/pets/petsSlice';
 import * as SC from './Nav.styled';
 
 export const Nav = () => {
-  const local = async () => {
-    await localStorage.setItem('categoryLocal', null);
-  };
+  const dispatch = useDispatch();
   return (
     <SC.Nav>
       <SC.List>
@@ -11,7 +11,10 @@ export const Nav = () => {
           <SC.Link to="/news">News</SC.Link>
         </SC.ListItem>
         <SC.ListItem>
-          <SC.Link to="/notices/sell" onClick={() => local()}>
+          <SC.Link
+            to="/notices/sell"
+            onClick={() => dispatch(updateCategory('sell'))}
+          >
             Find pet
           </SC.Link>
         </SC.ListItem>

--- a/src/components/Nav/Nav.jsx
+++ b/src/components/Nav/Nav.jsx
@@ -1,6 +1,9 @@
 import * as SC from './Nav.styled';
 
 export const Nav = () => {
+  const local = async () => {
+    await localStorage.setItem('categoryLocal', null);
+  };
   return (
     <SC.Nav>
       <SC.List>
@@ -8,7 +11,9 @@ export const Nav = () => {
           <SC.Link to="/news">News</SC.Link>
         </SC.ListItem>
         <SC.ListItem>
-          <SC.Link to="/notices/sell">Find pet</SC.Link>
+          <SC.Link to="/notices/sell" onClick={() => local()}>
+            Find pet
+          </SC.Link>
         </SC.ListItem>
         <SC.ListItem>
           <SC.Link to="/friends">Our friends</SC.Link>

--- a/src/components/Notice/ModalNotice/InfoPet/InfoPet.jsx
+++ b/src/components/Notice/ModalNotice/InfoPet/InfoPet.jsx
@@ -1,7 +1,10 @@
+import { categoriesHandler } from 'helpers/categoriesHandler';
+import { useCategory } from 'hooks/useCategory';
 import moment from 'moment';
 import style from './InfoPet.styled';
 
 export const InfoPet = ({ notice, toggle, favorite }) => {
+  const { activeCategory } = useCategory();
   const {
     breed,
     location,
@@ -31,7 +34,7 @@ export const InfoPet = ({ notice, toggle, favorite }) => {
 
   return (
     <Wrapper>
-      <Category>Sell</Category>
+      <Category>{categoriesHandler(activeCategory)}</Category>
       <Image src={avatarURL} alt="dog" />
 
       <WrapperGrid>

--- a/src/components/Notice/NoticeCategoryItem/NoticeCategoryItem.jsx
+++ b/src/components/Notice/NoticeCategoryItem/NoticeCategoryItem.jsx
@@ -42,10 +42,16 @@ export const NoticeCategoryItem = ({ fetch }) => {
   } = fetch;
 
   const categoryName = () => {
-    const uppercase = category.charAt().toUpperCase() + category.slice(1);
-    const result =
-      uppercase === 'Lost-found' ? uppercase.replace('-', '/') : uppercase;
-    return result.replaceAll('-', ' ');
+    switch (category) {
+      case 'sell':
+        return 'Sell';
+      case 'lost-found':
+        return 'Lost/found';
+      case 'in-good-hands':
+        return 'In good hands';
+      default:
+        break;
+    }
   };
 
   const { isLoggedIn, user } = useAuth();

--- a/src/components/Notice/NoticeCategoryItem/NoticeCategoryItem.jsx
+++ b/src/components/Notice/NoticeCategoryItem/NoticeCategoryItem.jsx
@@ -10,6 +10,7 @@ import {
   deleteUserPet,
 } from 'redux/notices/noticesOperations';
 import { useAuth } from 'hooks/useAuth';
+import { categoriesHandler } from 'helpers/categoriesHandler';
 
 const {
   Image,
@@ -40,19 +41,6 @@ export const NoticeCategoryItem = ({ fetch }) => {
     owner,
     category,
   } = fetch;
-
-  const categoryName = () => {
-    switch (category) {
-      case 'sell':
-        return 'Sell';
-      case 'lost-found':
-        return 'Lost/found';
-      case 'in-good-hands':
-        return 'In good hands';
-      default:
-        break;
-    }
-  };
 
   const { isLoggedIn, user } = useAuth();
   const dispatch = useDispatch();
@@ -100,7 +88,7 @@ export const NoticeCategoryItem = ({ fetch }) => {
   };
   return (
     <Card>
-      <Category>{categoryName()}</Category>
+      <Category>{categoriesHandler(category)}</Category>
       <Like type="button" onClick={handleFavoriteToggle}>
         {addedToFav ? <HeartIconFav /> : <HeartIcon />}
       </Like>

--- a/src/components/Notice/NoticeCategoryList/NoticeCategoryList.jsx
+++ b/src/components/Notice/NoticeCategoryList/NoticeCategoryList.jsx
@@ -21,18 +21,18 @@ export const NoticeCategoryList = ({ search, category }) => {
   useEffect(() => {
     const fetch = async () => {
       const categoryLocal = await localStorage.getItem('categoryLocal');
-      const categoryCheck = null || 'lost-found' || 'in-good-hands';
-      console.log(categoryLocal);
+      console.log('categoryLocal:', categoryLocal);
+      // console.log('category:', category);
 
-      if (category === '') {
-        (await categoryLocal) === categoryCheck
-          ? dispatch(fetchNotices('sell'))
-          : dispatch(fetchNotices(categoryLocal.replace(/['"]+/g, '')));
-      } else await dispatch(fetchNotices(category));
+      localStorage.getItem('categoryLocal') === 'null'
+        ? await dispatch(fetchNotices(category))
+        : await dispatch(fetchNotices(categoryLocal.replace(/['"]+/g, '')));
 
-      // (await category) === ''
-      //   ? dispatch(fetchNotices(categoryLocal))
-      //   : dispatch(fetchNotices(category));
+      // if (category === 'sell') {
+      //   (await categoryLocal) === null
+      //     ? dispatch(fetchNotices('sell'))
+      //     : dispatch(fetchNotices(categoryLocal.replace(/['"]+/g, '')));
+      // }
     };
     fetch();
   }, [category, dispatch]);

--- a/src/components/Notice/NoticeCategoryList/NoticeCategoryList.jsx
+++ b/src/components/Notice/NoticeCategoryList/NoticeCategoryList.jsx
@@ -21,9 +21,11 @@ export const NoticeCategoryList = ({ search, category }) => {
   useEffect(() => {
     const fetch = async () => {
       const categoryLocal = await localStorage.getItem('categoryLocal');
+      const categoryCheck = null || 'lost-found' || 'in-good-hands';
+      console.log(categoryLocal);
 
       if (category === '') {
-        (await categoryLocal) === null
+        (await categoryLocal) === categoryCheck
           ? dispatch(fetchNotices('sell'))
           : dispatch(fetchNotices(categoryLocal.replace(/['"]+/g, '')));
       } else await dispatch(fetchNotices(category));

--- a/src/components/Notice/NoticeCategoryList/NoticeCategoryList.jsx
+++ b/src/components/Notice/NoticeCategoryList/NoticeCategoryList.jsx
@@ -1,63 +1,81 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useCategory } from 'hooks/useCategory';
 import selectors from 'redux/notices/noticesSelectors';
 import { fetchNotices, getFavorites } from 'redux/notices/noticesOperations';
 import NoticeCategoryItem from '../NoticeCategoryItem';
 import { Grid } from './NoticeCategoryList.styled';
+import { getUserPets } from 'redux/user/userOperations';
+import { selectUserPets } from 'redux/user/userSelectors';
 // import { Loader } from 'components/Loader/Loader';
 
 const {
   selectNotices,
   // selectLoadingStatus,
   // selectErrorMessage,
+  selectUserFavorites,
 } = selectors;
 
-export const NoticeCategoryList = ({ search, category }) => {
+export const NoticeCategoryList = ({ search }) => {
   const noticesList = useSelector(selectNotices);
+  const favoritesList = useSelector(selectUserFavorites);
+  const userPetsList = useSelector(selectUserPets);
+
+  const { activeCategory } = useCategory();
   // const isLoading = useSelector(selectLoadingStatus);
   // const error = useSelector(selectErrorMessage);
   const dispatch = useDispatch();
 
   useEffect(() => {
     const fetch = async () => {
-      const categoryLocal = await localStorage.getItem('categoryLocal');
-      console.log('categoryLocal:', categoryLocal);
-      // console.log('category:', category);
+      switch (activeCategory) {
+        case 'favorite':
+          await dispatch(getFavorites());
+          break;
+        case 'my-ads':
+          await dispatch(getUserPets());
+          break;
 
-      localStorage.getItem('categoryLocal') === 'null'
-        ? await dispatch(fetchNotices(category))
-        : await dispatch(fetchNotices(categoryLocal.replace(/['"]+/g, '')));
-
-      // if (category === 'sell') {
-      //   (await categoryLocal) === null
-      //     ? dispatch(fetchNotices('sell'))
-      //     : dispatch(fetchNotices(categoryLocal.replace(/['"]+/g, '')));
-      // }
+        default:
+          await dispatch(fetchNotices(activeCategory));
+          break;
+      }
     };
     fetch();
-  }, [category, dispatch]);
+  }, [activeCategory, dispatch]);
 
-  function filterNotice() {
+  function filterNotice(list) {
     if (search.length === 0) {
-      return noticesList;
+      return list;
     }
-
     const normalizeSearch = search.toLocaleLowerCase();
-    const filterList = noticesList.filter(({ title }) =>
+    const filterList = list.filter(({ title }) =>
       title.toLowerCase().includes(normalizeSearch),
     );
     return filterList;
   }
 
-  const filterNoticeList = filterNotice();
+  const getList = () => {
+    switch (activeCategory) {
+      case 'favorite':
+        return filterNotice(favoritesList);
+      case 'my-ads':
+        return filterNotice(userPetsList);
+
+      default:
+        return filterNotice(noticesList);
+    }
+  };
+
+  // const filterNoticeList = filterNotice(noticesList);
 
   return (
     <>
       {/* {error && <p>Not found</p>} */}
       {/* {isLoading && <Loader />} */}
       <Grid>
-        {filterNoticeList.length > 0 &&
-          filterNoticeList.map(notice => {
+        {getList().length > 0 &&
+          getList().map(notice => {
             return <NoticeCategoryItem key={notice._id} fetch={notice} />;
           })}
       </Grid>

--- a/src/components/Notice/NoticesCategoriesNav/NoticesCategoriesNav.jsx
+++ b/src/components/Notice/NoticesCategoriesNav/NoticesCategoriesNav.jsx
@@ -4,16 +4,21 @@ import {
   CategoryItem,
 } from './NoticesCategoriesNav.styled';
 import { useAuth } from 'hooks/useAuth';
+import { useCategory } from 'hooks/useCategory';
+import { useDispatch } from 'react-redux';
+import { updateCategory } from 'redux/pets/petsSlice';
 
-export const NoticesCategoriesNav = ({ categoryChange }) => {
+export const NoticesCategoriesNav = () => {
   const { isLoggedIn } = useAuth();
+  const dispatch = useDispatch();
 
   return (
     <CategoriesList>
       <CategoryItem>
         <Link
           to="/notices/lost-found"
-          onClick={() => categoryChange('lost-found')}
+          onClick={() => dispatch(updateCategory('lost-found'))}
+          // onClick={() => categoryChange('lost-found')}
         >
           lost/found
         </Link>
@@ -22,27 +27,40 @@ export const NoticesCategoriesNav = ({ categoryChange }) => {
       <CategoryItem>
         <Link
           to="/notices/for-free"
-          onClick={() => categoryChange('in-good-hands')}
+          onClick={() => dispatch(updateCategory('in-good-hands'))}
         >
           in good hands
         </Link>
       </CategoryItem>
 
       <CategoryItem>
-        <Link to="/notices/sell" onClick={() => categoryChange('sell')}>
+        <Link
+          to="/notices/sell"
+          onClick={() => dispatch(updateCategory('sell'))}
+        >
           sell
         </Link>
       </CategoryItem>
 
       {isLoggedIn && (
         <CategoryItem>
-          <Link to="/notices/favorite">favorite ads</Link>
+          <Link
+            to="/notices/favorite"
+            onClick={() => dispatch(updateCategory('favorite'))}
+          >
+            favorite ads
+          </Link>
         </CategoryItem>
       )}
 
       {isLoggedIn && (
         <CategoryItem>
-          <Link to="/notices/own">my ads</Link>
+          <Link
+            to="/notices/own"
+            onClick={() => dispatch(updateCategory('my-ads'))}
+          >
+            my ads
+          </Link>
         </CategoryItem>
       )}
     </CategoriesList>

--- a/src/helpers/categoriesHandler.js
+++ b/src/helpers/categoriesHandler.js
@@ -1,0 +1,12 @@
+export const categoriesHandler = category => {
+  switch (category) {
+    case 'sell':
+      return 'Sell';
+    case 'lost-found':
+      return 'Lost/found';
+    case 'in-good-hands':
+      return 'In good hands';
+    default:
+      break;
+  }
+};

--- a/src/hooks/useCategory.js
+++ b/src/hooks/useCategory.js
@@ -1,0 +1,10 @@
+import { useSelector } from 'react-redux';
+import { getCategories } from 'redux/pets/petsSelectors';
+
+export const useCategory = () => {
+  const activeCategory = useSelector(getCategories);
+
+  return {
+    activeCategory,
+  };
+};

--- a/src/pages/NoticesPage/NoticesPage.jsx
+++ b/src/pages/NoticesPage/NoticesPage.jsx
@@ -16,7 +16,6 @@ const NoticesPage = () => {
   const [isBtnCategory, setBtnCategory] = useState('none');
   const [isShown, setIsShown] = useState(false);
   const [filter, setFilter] = useState('');
-  const [category, setCategory] = useState('sell');
   const initialValuesModalData = {
     category: '',
     title: '',
@@ -30,11 +29,6 @@ const NoticesPage = () => {
     comments: '',
   };
   const [modalData, setModalData] = useState(initialValuesModalData);
-
-  const categoryChange = category => {
-    localStorage.setItem('categoryLocal', JSON.stringify(category));
-    setCategory(category);
-  };
 
   const adminModal = (type, value) => {
     setIsShown(!value);
@@ -71,9 +65,9 @@ const NoticesPage = () => {
                 modalData={modalData}
               />
             )}
-            <NoticesCategoriesNav categoryChange={categoryChange} />
+            <NoticesCategoriesNav />
           </PetSearchNav>
-          <NoticeCategoryList search={filter} category={category} />
+          <NoticeCategoryList search={filter} />
         </Container>
       </section>
     </Main>

--- a/src/pages/NoticesPage/NoticesPage.jsx
+++ b/src/pages/NoticesPage/NoticesPage.jsx
@@ -16,7 +16,7 @@ const NoticesPage = () => {
   const [isBtnCategory, setBtnCategory] = useState('none');
   const [isShown, setIsShown] = useState(false);
   const [filter, setFilter] = useState('');
-  const [category, setCategory] = useState('');
+  const [category, setCategory] = useState('sell');
   const initialValuesModalData = {
     category: '',
     title: '',

--- a/src/redux/notices/noticesSlice.js
+++ b/src/redux/notices/noticesSlice.js
@@ -14,6 +14,7 @@ const noticesInitialState = {
   favorites: [],
   isLoading: false,
   error: null,
+  activeCategory: 'sell',
 };
 
 const extraActions = [
@@ -37,6 +38,7 @@ const onFetchFavoritesSuccessReducer = (state, action) => {
   state.favorites = action.payload;
   state.isLoading = false;
   state.error = null;
+  state.activeCategory = 'sell';
 };
 
 const onAddFavNoticeReducer = (state, action) => {

--- a/src/redux/pets/petsSelectors.js
+++ b/src/redux/pets/petsSelectors.js
@@ -1,0 +1,1 @@
+export const getCategories = state => state.pets.category;

--- a/src/redux/pets/petsSlice.js
+++ b/src/redux/pets/petsSlice.js
@@ -1,0 +1,19 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const petsInitialState = {
+  category: 'sell',
+};
+
+const petsSlice = createSlice({
+  name: 'pets',
+  initialState: petsInitialState,
+  reducers: {
+    updateCategory(state, action) {
+      state.category = action.payload;
+    },
+  },
+});
+
+export const petsReducer = petsSlice.reducer;
+
+export const { updateCategory } = petsSlice.actions;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -4,6 +4,7 @@ import storage from 'redux-persist/lib/storage';
 import { authReducer } from './auth/authSlice';
 import { noticesReducer } from './notices/noticesSlice';
 import { userReducer } from './user/userSlice';
+import { petsReducer } from './pets/petsSlice';
 
 const persistConfig = {
   key: 'auth',
@@ -11,11 +12,17 @@ const persistConfig = {
   whitelist: ['token', 'isLoggedIn'],
 };
 
+const persistConfig2 = {
+  key: 'category',
+  storage,
+};
+
 export const store = configureStore({
   reducer: {
     auth: persistReducer(persistConfig, authReducer),
     user: userReducer,
     notices: noticesReducer,
+    pets: persistReducer(persistConfig2, petsReducer),
   },
   middleware: getDefaultMiddleware =>
     getDefaultMiddleware({

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -6,23 +6,23 @@ import { noticesReducer } from './notices/noticesSlice';
 import { userReducer } from './user/userSlice';
 import { petsReducer } from './pets/petsSlice';
 
-const persistConfig = {
+const persistConfigUser = {
   key: 'auth',
   storage,
   whitelist: ['token', 'isLoggedIn'],
 };
 
-const persistConfig2 = {
+const persistConfigCategory = {
   key: 'category',
   storage,
 };
 
 export const store = configureStore({
   reducer: {
-    auth: persistReducer(persistConfig, authReducer),
+    auth: persistReducer(persistConfigUser, authReducer),
     user: userReducer,
     notices: noticesReducer,
-    pets: persistReducer(persistConfig2, petsReducer),
+    pets: persistReducer(persistConfigCategory, petsReducer),
   },
   middleware: getDefaultMiddleware =>
     getDefaultMiddleware({


### PR DESCRIPTION
1. Сделал категории через Redux. Добавил petsSlice, куда сохраняется информация о последней активной категории пэтов, которые смотрел пользователь. По умолчанию "Sell". Подлючен Redux Persist, поэтому данные также сохраняются в LocalStorage, что позволяет категории пэтов не слетать при перезагрузке страницы. При нажатии на Find Pet в хэдэре категория в сторе сбрасывается на Sell и в компоненте NoticeCategoryList срабатывает перерендер карточек.
2. Также теперь из редакс стора тянется информация о текущей категории и таким образом отрисовывается название категории в модалке (компонент InfoPet), а также в самих карточках пэтов на странице FindPet (компонент NoticeCategoryItem). Чтобы не было дефисов и названия категория были с большой буквы - добавил функцию categoriesHandler в папку helpers. Она просто преобразует названия в подходящий вид.
3. Для авторизованного пользователя тоже рендерятся списки для кнопок favourites и my ads. My ads не тестил. В favorites при первом рендере валится сборка (потом можно перезагрузить и уже все будет ок). Сейчас буду разбираться и пофикшу в следующем коммите.